### PR TITLE
doc: add package doc

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Go Authors. All rights reserved.
+// Copyright 2018 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,9 @@
+// Copyright 2017 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package scratch is mainly for use by people learning how to use Gerrit and
+// contribute to Go.
+//
+// Read the README.md to access the tutorial.
+package scratch

--- a/doc.go
+++ b/doc.go
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// Package scratch is mainly for use by people learning how to use Gerrit and
-// contribute to Go.
+// Package scratch exists mainly for people to learn how to use Gerrit
+// and contribute to Go.
 //
 // Read the README.md to access the tutorial.
 package scratch


### PR DESCRIPTION
The package has no package comment for godoc to display, as seen at
https://godoc.org/go.googlesource.com/scratch.git or
https://godoc.org/goscratch.club. Adding a short description that gives
some context will help visitors to the godoc.

Fixes golang/go#27427