### PR TITLE
cherry: replace os.SEEK_SET with io.SeekStart

### DIFF
--- a/cherry/codesign.go
+++ b/cherry/codesign.go
@@ -315,7 +315,7 @@ func main() {
 	outp = puts(outp, []byte(id))
 
 	// emit hashes
-	_, err = f.Seek(0, os.SEEK_SET)
+	_, err = f.Seek(0, io.SeekStart)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Because os.SEEK_SET has been deprecated, using io.SeekStart instead.